### PR TITLE
Fix link not in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ https://www.guilded.gg/b/c0385537-2d9f-4c71-9cd6-78f46a26a337
 
 <h1>Info</h1>
 Public tracker for feature requests & bug reports for the Guilded Roblox Verification bot.
+
 Please submit any bug or feature requests [here](https://github.com/InceptionTime/GuildedRobloxVerification/issues)
 
 Code for the bot will remain private.


### PR DESCRIPTION
Adds a new line to fix the `[here](https://github.com/InceptionTime/GuildedRobloxVerification/issues)` not rendering properly in the README.

### Before
![image](https://github.com/InceptionTime/GuildedRobloxVerification/assets/80087248/924864cd-17d4-4479-a7ed-8bba761744ed)

### After
![image](https://github.com/InceptionTime/GuildedRobloxVerification/assets/80087248/5aace286-bd10-4d58-94ce-7143c8d33466)
